### PR TITLE
Tests: Create Buy Order

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,19 @@
 # Development workflow
 
+## Project description
+Rest API to manage BTC buy orders. Client places order to purchase BTC
+for fiat at a market price. API does not create transactions on the Bitcoin
+blockchain, but simply stores the order information in its database for further
+processing.
+
+### Requirements
+* Uses coindesk.com exchange rates
+* Currency is described with ISO3 code (EUR, GBP, USD)
+* Sum of bitcoin amount of all orders stored in the system must not exceed 
+  100BTC. System must not allow creation of new orders which would cause the
+  constraint to be violated.
+* BTC use a precision of 8 decimal digits, and always round up.
+
 ## Prerequisites
 - docker
 - docker-compose

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,3 +13,4 @@ services:
       - 8000:80
     environment:
       - CONFIG_FILE=/app/config.ini
+      - COINDESK_API_URL=https://api.coindesk.com/v1/

--- a/requirements_tests.txt
+++ b/requirements_tests.txt
@@ -1,2 +1,3 @@
 pytest==6.2.5
 pytest-cov==3.0.0
+hypothesis==6.24.0

--- a/requirements_tests.txt
+++ b/requirements_tests.txt
@@ -1,3 +1,4 @@
+factory_boy==3.2.0
 pytest==6.2.5
 pytest-cov==3.0.0
 hypothesis==6.24.0

--- a/requirements_tests.txt
+++ b/requirements_tests.txt
@@ -1,4 +1,6 @@
 factory_boy==3.2.0
+hypothesis==6.24.0
 pytest==6.2.5
 pytest-cov==3.0.0
-hypothesis==6.24.0
+pytz==2021.1
+requests-mock==1.9.3

--- a/src/application/api/__init__.py
+++ b/src/application/api/__init__.py
@@ -1,7 +1,7 @@
 from fastapi import FastAPI
 from injector import Injector, Module, provider, singleton
 
-from . import monitors
+from . import monitors, ordering
 
 
 class APIModule(Module):
@@ -11,6 +11,7 @@ class APIModule(Module):
         app = FastAPI()
         app.state.injector = container
         app.include_router(monitors.router, prefix="/monitors")
+        app.include_router(ordering.router, prefix="/orders")
         return app
 
 

--- a/src/application/api/ordering.py
+++ b/src/application/api/ordering.py
@@ -1,0 +1,52 @@
+from decimal import Decimal
+from typing import Text
+from uuid import UUID
+
+from fastapi import APIRouter, Body
+from pydantic import BaseModel, condecimal
+
+from currency import Currency
+
+router = APIRouter()
+
+
+class BuyOrder(BaseModel):
+    id: UUID
+    request_id: UUID
+    bitcoins: condecimal(decimal_places=8)
+    bought_for: condecimal(decimal_places=4)
+    currency: Currency
+
+
+@router.get(
+    "/{order_id}", name="orders:get_order", response_model=BuyOrder,
+)
+async def get_order(order_id: UUID) -> BuyOrder:
+    raise NotImplementedError
+
+
+class CreateBuyOrderError(BaseModel):
+    detail: Text
+
+
+class BuyOrderCreated(BaseModel):
+    order_id: UUID
+    location: Text
+
+
+@router.post(
+    "/", name="orders:create_order",
+    status_code=201,
+    response_model=BuyOrderCreated,
+    responses={409: {"model": CreateBuyOrderError}},
+)
+async def create_order(
+        request_id: UUID = Body(...),
+        amount: condecimal(
+            decimal_places=4, gt=Decimal(0), lt=Decimal(1_000_000_000),
+        ) = Body(...),
+        currency: Currency = Body(...),
+) -> BuyOrderCreated:
+    raise NotImplementedError
+
+__all__ = ["router"]

--- a/src/application/settings.py
+++ b/src/application/settings.py
@@ -9,3 +9,6 @@ class Settings(BaseSettings):
         join(dirname(__file__), "..", "..", "config.ini"),
         env="CONFIG_FILE",
     )
+    coindesk_api_url: Text = Field(
+        "https://api.coindesk.com/v1/", env="COINDESK_API_URL",
+    )

--- a/src/currency/__init__.py
+++ b/src/currency/__init__.py
@@ -1,0 +1,10 @@
+from enum import Enum
+
+
+class Currency(str, Enum):
+    GBP = "GBP"
+    EUR = "EUR"
+    USD = "USD"
+
+
+__all__ = ["Currency"]

--- a/tests/application/factories.py
+++ b/tests/application/factories.py
@@ -1,0 +1,8 @@
+from factory import DictFactory, Faker
+from factory.fuzzy import FuzzyChoice
+
+
+class ApiCreateBuyOrderRequestFactory(DictFactory):
+    request_id = Faker("uuid4")
+    amount = Faker("pyfloat", right_digits=4, min_value=1, max_value=400)
+    currency = FuzzyChoice(["EUR", "GBP", "USD"])

--- a/tests/application/test_api.py
+++ b/tests/application/test_api.py
@@ -1,0 +1,50 @@
+from random import random
+from uuid import uuid4
+
+from pytest import mark
+
+from .factories import ApiCreateBuyOrderRequestFactory as CreateBuyOrder
+
+CREATE_ORDER_URL = "/orders/"
+
+
+class TestCreateBuyOrderRequest:
+    @mark.xfail(raises=NotImplementedError, strict=True)
+    def test_after_creating_redirects_to_created_order(self, api_client):
+        request = CreateBuyOrder()
+        response = api_client.post(CREATE_ORDER_URL, json=request)
+        assert response.status_code == 201
+        order_url = response.headers["Location"]
+        order = api_client.get(order_url).json()
+        assert order["request_id"] == request["request_id"]
+
+    @mark.xfail(raises=NotImplementedError, strict=True)
+    def test_creating_order_is_idempotent(self, api_client):
+        request = CreateBuyOrder()
+        first = api_client.post(CREATE_ORDER_URL, json=request)
+        second = api_client.post(CREATE_ORDER_URL, json=request)
+        assert first.headers["Location"] == second.headers["Location"]
+
+    @mark.parametrize(
+        "request_id", ["ILLEGAL", uuid4().hex[:-3], "", random(), None]
+    )
+    def test_reject_when_no_uuid_id(self, api_client, request_id):
+        request = CreateBuyOrder().update(request_id=request_id)
+        response = api_client.post(CREATE_ORDER_URL, json=request)
+        assert response.status_code == 422
+
+    def test_reject_when_negative_amount(self, api_client):
+        request = CreateBuyOrder().update(amount=-1)
+        response = api_client.post(CREATE_ORDER_URL, json=request)
+        assert response.status_code == 422
+
+    def test_reject_when_amount_higher_than_1_000_000_000(self, api_client):
+        request = CreateBuyOrder().update(amount=1_000_000_000)
+        response = api_client.post(CREATE_ORDER_URL, json=request)
+        assert response.status_code == 422
+
+    @mark.parametrize("currency", ["PLN", "AUD", "XXX"])
+    def test_reject_when_currency_not_eur_gbp_usd(self, api_client, currency):
+        request = CreateBuyOrder().update(currency=currency)
+        response = api_client.post(CREATE_ORDER_URL, json=request)
+        assert response.status_code == 422

--- a/tests/application/test_ordering.py
+++ b/tests/application/test_ordering.py
@@ -1,0 +1,79 @@
+from __future__ import annotations
+
+import decimal
+from decimal import Decimal
+from typing import Optional, Text
+
+from hypothesis import HealthCheck, given, settings
+from hypothesis.strategies import decimals
+from pytest import fixture, mark
+
+
+class TestOrdering:
+    @mark.xfail(raises=NotImplementedError, strict=True)
+    @mark.parametrize("currency", ["EUR", "GBP", "USD"])
+    def test_creating_an_order(self, currency: Text, ordering):
+        ordering.when_creating_buy_order_with(currency=currency)
+        ordering.assert_that_order_was_created()
+
+    @mark.xfail(raises=NotImplementedError, strict=True)
+    def test_created_order_uses_current_exchange_rate(self, ordering):
+        ordering.given_1btc_exchange_rate(EUR=33_681.3874)
+        ordering.when_creating_buy_order_with(33_681.3874, "EUR")
+        ordering.assert_that_order_was_created(with_bitcoins=1)
+
+    @mark.xfail(raises=NotImplementedError, strict=True)
+    def test_summary_amount_of_orders_cannot_exceed_100btc(self, ordering):
+        ordering.given_1btc_exchange_rate(EUR=100)
+        ordering.given_created_order_with(bitcoins=50)
+        ordering.given_created_order_with(bitcoins=50)
+        ordering.when_creating_buy_order_with(2000, "EUR")
+        ordering.expect_failure_for("Exceeded 100BTC ordering limit")
+
+    @mark.xfail(raises=NotImplementedError, strict=True)
+    @given(
+        paid=decimals(min_value=0.0001, max_value=999.9999, places=4),
+        exchange_rate=decimals(min_value=20_000, max_value=90_000, places=4),
+    )
+    @settings(suppress_health_check=[HealthCheck.function_scoped_fixture])
+    def test_bought_bitcoins_are_round_up_with_precision_of_8_digits(
+            self, paid: Decimal, exchange_rate: Decimal, ordering,
+    ):
+        ordering.given_1btc_exchange_rate(EUR=exchange_rate)
+        ordering.when_creating_buy_order_with(paid, "EUR")
+        ordering.assert_that_order_was_created(
+            with_bitcoins=round_up(paid/exchange_rate, to_precision=8),
+        )
+
+
+def round_up(amount: float | Decimal, to_precision: int) -> Decimal:
+    exp = Decimal(10) ** -to_precision
+    return Decimal(amount).quantize(exp, rounding=decimal.ROUND_UP)
+
+
+class OrderingSteps:
+    def given_1btc_exchange_rate(self, **rates: Decimal | float) -> None:
+        raise NotImplementedError
+
+    def given_created_order_with(self, bitcoins: float | Decimal) -> None:
+        raise NotImplementedError
+
+    def when_creating_buy_order_with(
+            self,
+            amount: Optional[float | Decimal] = None,
+            currency: Optional[Text] = None,
+    ) -> None:
+        raise NotImplementedError
+
+    def assert_that_order_was_created(
+            self, with_bitcoins: Optional[float | Decimal] = None,
+    ) -> None:
+        raise NotImplementedError
+
+    def expect_failure_for(self, with_reason: Optional[Text] = None) -> None:
+        raise NotImplementedError
+
+
+@fixture
+def ordering() -> OrderingSteps:
+    return OrderingSteps()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,6 +4,7 @@ from pytest import fixture
 
 from application.app import create_app
 from application.settings import Settings
+from tests.tools import CoinDeskApiStub
 
 
 @fixture
@@ -19,3 +20,10 @@ def container(app) -> Injector:
 @fixture
 def settings(container) -> Settings:
     return container.get(Settings)
+
+
+@fixture
+def coindesk(settings: Settings) -> CoinDeskApiStub:
+    coindesk_mock = CoinDeskApiStub(settings.coindesk_api_url)
+    with coindesk_mock() as coindesk:
+        yield coindesk

--- a/tests/tools.py
+++ b/tests/tools.py
@@ -1,0 +1,79 @@
+from contextlib import contextmanager
+from datetime import datetime
+from decimal import Decimal
+from typing import Dict, Optional, Text
+from urllib.parse import urljoin
+
+import pytz
+import requests_mock
+
+
+class CoinDeskApiStub:
+    CURRENCIES = ["EUR", "GBP", "USD"]
+
+    def __init__(
+            self, url: Text, when_last_update: Optional[datetime] = None,
+    ) -> None:
+        self._url = url
+        self._index: Dict[Text, Decimal] = {
+            "EUR": Decimal(39_170.1564),
+            "GBP": Decimal(33_681.3874),
+            "USD": Decimal(46_269.1377),
+        }
+        self._mark_as_updated(at=when_last_update)
+
+    @contextmanager
+    def __call__(self) -> "CoinDeskApiStub":
+        with requests_mock.mock(real_http=True) as http:
+            http.get(
+                urljoin(self._url, "bpi/currentprice.json"),
+                json=self._generate_response,
+            )
+            yield self
+
+    def _generate_response(self, request, context) -> Dict:
+        datetime_format = '%b %d, %Y %H:%M:%S %Z'
+        utc = pytz.timezone("UTC").localize(self._last_update)
+        bst = pytz.timezone("Europe/London").localize(self._last_update)
+        return {
+            "time": {
+                "updated": utc.strftime(datetime_format),
+                "updatedISO": self._last_update.isoformat(),
+                "updateduk": bst.strftime(datetime_format),
+            },
+            "disclaimer": (
+                "This data was produced from the "
+                "CoinDesk Bitcoin Price Index (USD). "
+                "Non-USD currency data converted using hourly conversion rate "
+                "from openexchangerates.org"
+            ),
+            "chartName": "Bitcoin",
+            "bpi": {
+                currency: {
+                    "code": currency,
+                    "symbol": {
+                        "USD": "&#36;",
+                        "GBP": "&pound;",
+                        "EUR": "&euro;",
+                    }[currency],
+                    "rate": f"{rate:,.4f}",
+                    "description": {
+                        "USD": "United States Dollar",
+                        "GBP": "British Pound Sterling",
+                        "EUR": "Euro",
+                    },
+                    "rate_float": float(f"{rate:.4f}"),
+                }
+                for currency, rate in self._index.items()
+            },
+        }
+
+    def _mark_as_updated(self, at: Optional[datetime] = None) -> None:
+        self._last_update = at or datetime.utcnow()
+
+    def get_bitcoin_rate(self, for_currency: CURRENCIES) -> Decimal:
+        return self._index[for_currency]
+
+    def set_current(self, rate: Decimal, for_currency: CURRENCIES) -> None:
+        self._index[for_currency] = rate
+        self._mark_as_updated()


### PR DESCRIPTION
# Create Buy Order feature tests
This MR is only tested for Feature requirements and API proposition.

## Feature description
API allows its clients to manage BTC buy orders. Clients place orders to purchase BTC
for fiat at a market price. API does not create transactions on the Bitcoin blockchain,
but simply stores the order information in its database for further processing.

1.  Creation of a Buy Order requires the following data at minimum:
 * currency - represents the currency (ISO3 code one of: EUR, GBP, USD)
 * amount - represents the amount of currency (0 < x < 1,000,000,000)
2. Buy Order creation must be idempotent.
3. amount of BTC which is the requested amount of fiat buys at the exchange rate. Use a precision of 8 decimal digits, and always round up. Do not lose precision in calculations.
4. Sum of bitcoin amount of all orders stored in the system must not exceed 100BTC.
   System must not allow creation of new orders which would cause the constraint to
be violated.